### PR TITLE
Do not longer call find_package in package config.

### DIFF
--- a/config.cmake.in
+++ b/config.cmake.in
@@ -12,12 +12,6 @@
 set(@PROJECT_NAME@_INSTALL_DIR @PACKAGE_INCLUDE_INSTALL_DIR@)
 set(@PROJECT_NAME@_GLOBAL_INSTALL_DIR @PACKAGE_GLOBAL_INCLUDE_INSTALL_DIR@)
 
-# find_package will silently look for the dependencies and set the correct
-# include directories and link libraries
-foreach(PACKAGE @DEPENDENT_PACKAGES@)
-    find_package(${PACKAGE} QUIET)
-endforeach()
-
 foreach(PACKAGE @DEPENDENT_PACKAGES@)
     check_required_components(${PACKAGE})
 endforeach()


### PR DESCRIPTION
It is up to the caller to assemble all these dependencies.
Fixes #1