### PR TITLE
Fix lcov cannot write to file error.

### DIFF
--- a/src/CodeCoverage.cmake
+++ b/src/CodeCoverage.cmake
@@ -70,21 +70,23 @@ if(CODE_COVERAGE)
         set(LCOV_REDIRECT "2>/dev/null")
     endif()
 
+    set(COVERAGE_FILE ${CMAKE_BINARY_DIR}/coverage.info)
+
     add_custom_target("coverage-report")
     add_custom_command(TARGET "coverage-report"
-        COMMAND ${LCOV_EXECUTABLE} --quiet --capture --directory . --base-directory ${CMAKE_SOURCE_DIR} --no-external -o coverage.info ${LCOV_REDIRECT}
-        COMMAND ${LCOV_EXECUTABLE} --quiet --remove coverage.info ${CODE_COVERAGE_EXCLUDES} -o coverage.info
-        COMMAND ${LCOV_EXECUTABLE} --quiet --remove coverage.info \*test_\* -o coverage.info
-        COMMAND ${LCOV_EXECUTABLE} --quiet --remove coverage.info \*catch.hpp\* -o coverage.info
-        COMMAND ${LCOV_EXECUTABLE} --quiet --remove coverage.info \*contract.cpp\* -o coverage.info
-        COMMAND ${LCOV_EXECUTABLE} --list coverage.info
-        COMMAND ${LCOV_EXECUTABLE} --summary coverage.info
+        COMMAND ${LCOV_EXECUTABLE} --quiet --capture --directory . --base-directory ${CMAKE_SOURCE_DIR} --no-external -o ${COVERAGE_FILE} ${LCOV_REDIRECT}
+        COMMAND ${LCOV_EXECUTABLE} --quiet --remove ${COVERAGE_FILE} ${CODE_COVERAGE_EXCLUDES} -o ${COVERAGE_FILE}
+        COMMAND ${LCOV_EXECUTABLE} --quiet --remove ${COVERAGE_FILE} \*test_\* -o ${COVERAGE_FILE}
+        COMMAND ${LCOV_EXECUTABLE} --quiet --remove ${COVERAGE_FILE} \*catch.hpp\* -o ${COVERAGE_FILE}
+        COMMAND ${LCOV_EXECUTABLE} --quiet --remove ${COVERAGE_FILE} \*contract.cpp\* -o ${COVERAGE_FILE}
+        COMMAND ${LCOV_EXECUTABLE} --list ${COVERAGE_FILE}
+        COMMAND ${LCOV_EXECUTABLE} --summary ${COVERAGE_FILE}
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         COMMENT "Create code coverage report")
 
     add_custom_target("coverage-html" DEPENDS "coverage-report")
     add_custom_command(TARGET "coverage-html"
-        COMMAND ${GENHTML_EXECUTABLE} coverage.info --show-details -o coverage
+        COMMAND ${GENHTML_EXECUTABLE} ${COVERAGE_FILE} --show-details -o coverage
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         COMMENT "Create code coverage html report"
         VERBATIM)


### PR DESCRIPTION
On Ubuntu xenial (16.04), lcov gives an error when writing to coverage.info.  It happens upon commands to process the CODE_COVERAGE_EXCLUDES entries, but not when generating the coverage.info file for the first time.   It appears lcov is writing to root directory "/" at some point which causes the problem (see https://stackoverflow.com/questions/37675961/error-while-code-coverage-report-using-lcov).  This change fixes the problem by specifying the full file path.