### PR TITLE
Remove ALLOW_RTTI flag because it can only be used at project level, …

### DIFF
--- a/src/CompilerFlags.cmake
+++ b/src/CompilerFlags.cmake
@@ -157,10 +157,8 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # Remove /EHsc since /EHsc- will be added (otherwise we get a warning about replacing /EHsc with /EHsc-)
     string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 
-    if (NOT ${ALLOW_RTTI})
-        # Remove /GR since /GR- will be added (otherwise we get a warning about replacing /GR with /GR-)
-        string(REPLACE "/GR" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
-    endif()
+    # Remove /GR since /GR- will be added (otherwise we get a warning about replacing /GR with /GR-)
+    string(REPLACE "/GR" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 
     set(COMPILER_FLAGS
                         "/W4"
@@ -185,11 +183,8 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
                         "/wd4718"   # Workaround for https://bugreports.qt.io/browse/QTBUG-54089
                         "/nologo"
                         "/EHsc-"    # disable exceptions
+                        "/GR-"      # disable RTTI
     )
-
-    if (NOT ${ALLOW_RTTI})
-        list(APPEND COMPILER_FLAGS "/GR-")  # disable RTTI
-    endif()
 endif()
 
 # Allow workarounds for specific frameworks 
@@ -199,13 +194,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
     endif()
     if (NOT ${ALLOW_EXCEPTIONS})
         list(APPEND COMPILER_FLAGS "-fno-exceptions")
-    endif()
-
-    if (NOT DEFINED ALLOW_RTTI)
-        option(ALLOW_RTTI "Allow runtime type information (RTTI)" OFF)
-    endif()
-    if (NOT ${ALLOW_RTTI})
-        list(APPEND COMPILER_FLAGS "-fno-rtti")  # disable runtime type information
     endif()
 endif()
 
@@ -224,10 +212,9 @@ endif (NOT WIN32)
 
 # Adds reverted compiler flags for compiling with FakeIt to the specified target
 #   _TARGET       - The target to revert compile flag for
-# Note: RTTI needs to be enabled using ENABLE_RTTI (for MSVC only) before this file is included
 macro(target_uses_fakeit _TARGET)
-    if(NOT MSVC)
-        set(REVERT_COMPILER_OPTIONS
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(${_TARGET} PRIVATE
             -frtti
             -fexceptions
             -Wno-effc++
@@ -235,15 +222,16 @@ macro(target_uses_fakeit _TARGET)
             -Wno-old-style-cast
             -Wno-sign-conversion
         )
-        target_compile_options(${_TARGET} PRIVATE "${REVERT_COMPILER_OPTIONS}")
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        target_compile_options(${_TARGET} PRIVATE /GR)  # ignore generated warning
     endif()
+
     # Additions for Clang only
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        set(REVERT_COMPILER_OPTIONS
+        target_compile_options(${_TARGET} PRIVATE
             -Wno-shorten-64-to-32
             -Wno-deprecated
             -Wno-zero-length-array
         )
-        target_compile_options(${_TARGET} PRIVATE "${REVERT_COMPILER_OPTIONS}")
     endif()
 endmacro()


### PR DESCRIPTION
- Remove `ALLOW_RTTI` flag because it can only be used at project level, instead overrule flag for MSVC.
- See extra comment in the commit message:

> Be aware that for GCC, all mocked classes need to be compiled also with RTTI enabled.

This seems not the case for a simple class (don't know yet how simple...)
On HAL, I'm starting by trying to define an interface class (pure virtual, so it's header only) for as the base class of the mocked class BarcoDisplayProtocol, to solve the linker issues when compiling with GCC.
- For MSVC, the RTTI is overwritten just like for GCC & clang, so there will be a warning. I don't see another way of doing this. Apparently, there is something in the making to solve this issue https://gitlab.kitware.com/cmake/cmake/issues/19084#. So for now we should just ignore it.