### PR TITLE
Improvement: no need to ignore warnings for target build with RTTI

### DIFF
--- a/src/CompilerFlags.cmake
+++ b/src/CompilerFlags.cmake
@@ -210,28 +210,15 @@ if (NOT WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif (NOT WIN32)
 
-# Adds reverted compiler flags for compiling with FakeIt to the specified target
+# Adds reverted compiler flags for compiling the target with rtti
 #   _TARGET       - The target to revert compile flag for
-macro(target_uses_fakeit _TARGET)
+macro(target_compile_with_rtti _TARGET)
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         target_compile_options(${_TARGET} PRIVATE
             -frtti
             -fexceptions
-            -Wno-effc++
-            -Wno-non-virtual-dtor
-            -Wno-old-style-cast
-            -Wno-sign-conversion
         )
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         target_compile_options(${_TARGET} PRIVATE /GR)  # ignore generated warning
-    endif()
-
-    # Additions for Clang only
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        target_compile_options(${_TARGET} PRIVATE
-            -Wno-shorten-64-to-32
-            -Wno-deprecated
-            -Wno-zero-length-array
-        )
     endif()
 endmacro()


### PR DESCRIPTION
After learning more about CMake targets, there is a way to ignore all warnings from an external source using the SYSTEM keyword. E.g.:

```cmake
target_include_directories(${TARGET_NAME}
    SYSTEM PUBLIC
        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/tools/mocking>
)
```
In this case, there's no need to ignore warnings caused within the fakeit header.
Another advantage is that, the warnings within the rest of the files build within this target cannot be ignored!
