### PR TITLE
Revert "Improvement: no need to ignore warnings for target build with RTTI"

### DIFF
--- a/src/CompilerFlags.cmake
+++ b/src/CompilerFlags.cmake
@@ -210,15 +210,28 @@ if (NOT WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif (NOT WIN32)
 
-# Adds reverted compiler flags for compiling the target with rtti
+# Adds reverted compiler flags for compiling with FakeIt to the specified target
 #   _TARGET       - The target to revert compile flag for
-macro(target_compile_with_rtti _TARGET)
+macro(target_uses_fakeit _TARGET)
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         target_compile_options(${_TARGET} PRIVATE
             -frtti
             -fexceptions
+            -Wno-effc++
+            -Wno-non-virtual-dtor
+            -Wno-old-style-cast
+            -Wno-sign-conversion
         )
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         target_compile_options(${_TARGET} PRIVATE /GR)  # ignore generated warning
+    endif()
+
+    # Additions for Clang only
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        target_compile_options(${_TARGET} PRIVATE
+            -Wno-shorten-64-to-32
+            -Wno-deprecated
+            -Wno-zero-length-array
+        )
     endif()
 endmacro()


### PR DESCRIPTION
Reverts cmakespark/cmake#32, reasons:
1. HAL was not using the correct cmakespark version for testing so it was tested incorrectly 😞 
   The SYSTEM flag doesn't seem to work after all, most likely because fakeit is header only, propagating all warnings to the compiled object files from the target.
2. I realized that for fakeit also _exceptions_ are enabled (see macro), resulting in a wrong name substitute ~~`target_compile_with_rtti`~~
3. Afterall, by disabling warnings inside the macro when using fakeit, the developer doesn't need to care about how to include fakeit. The only downside is still that these warnings are ignored in the test code (still a minor issue)