### PR TITLE
Disable effc++ warning because of a false positive GCC bug

### DIFF
--- a/src/CompilerFlags.cmake
+++ b/src/CompilerFlags.cmake
@@ -46,9 +46,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
                         "-Wunreachable-code"
                         "-mfpmath=sse"                      # needed on Debian 32-bit to get high precision floating point operations
                         "-msse2"                            # needed on Debian 32-bit to get high precision floating point operations
-
-                        "-Weffc++"                          # warnings from Effective C++ book;
-
+#                        "-Weffc++"                         # warnings from Effective C++ book; Disabled due to false positive on member init
                         "-Werror"
                         "-Wformat-nonliteral"               # const char* argumements could not langer be passed due to this entry
 #                       "-Winline"                          # gcc on Linux seems to decide frequently not to inline, and warns about it.


### PR DESCRIPTION
It's time to fix this issue, as I have seen this before and did changes that weren't necessary.

Issue I encountered:
```cpp
class DisplayConfig {
...
    DisplayInfo = default()
...
    unsigned int m_uiFlag;
    std::vector<DisplayInfo> m_displays;
    int m_selectedDisplay;
}
```

The incorrect error because the members are initialized:
```
1752/home/travis/build/barco-healthcare/hal/displaycommunication/src/transport/displayconfig_unix.cpp: In constructor ‘DisplayConfig::DisplayConfig()’:
1753/home/travis/build/barco-healthcare/hal/displaycommunication/src/transport/displayconfig_unix.cpp:7:1: error: ‘DisplayConfig::m_uiFlag’ should be initialized in the member initialization list [-Werror=effc++]
1754 DisplayConfig::DisplayConfig()
1755 ^~~~~~~~~~~~~
1756/home/travis/build/barco-healthcare/hal/displaycommunication/src/transport/displayconfig_unix.cpp:7:1: error: ‘DisplayConfig::m_displays’ should be initialized in the member initialization list [-Werror=effc++]
1757/home/travis/build/barco-healthcare/hal/displaycommunication/src/transport/displayconfig_unix.cpp:7:1: error: ‘DisplayConfig::m_selectedDisplay’ should be initialized in the member initialization list [-Werror=effc++]
1758cc1plus: all warnings being treated as errors
```

See the bug here: 
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=16166#c3

Here it is explained:
https://stackoverflow.com/q/14002454/2522849

**Solution**: remove -Weffc++ from the compiler flags. There is still the one for Clang, which doesn't have this issue.