### PR TITLE
Bugfix/samja coverage

### DIFF
--- a/src/CodeCoverage.cmake
+++ b/src/CodeCoverage.cmake
@@ -83,6 +83,7 @@ if(CODE_COVERAGE)
     add_custom_target("coverage-html" DEPENDS "coverage-report")
     add_custom_command(TARGET "coverage-html"
         COMMAND ${GENHTML_EXECUTABLE} ${COVERAGE_FILE} --show-details -o coverage
+        COMMAND ${CMAKE_COMMAND} -E tar cf CodeCoverage.zip --format=zip -- coverage
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         COMMENT "Create code coverage html report"
         VERBATIM)

--- a/src/CodeCoverage.cmake
+++ b/src/CodeCoverage.cmake
@@ -50,9 +50,10 @@ if(NOT CODE_COVERAGE_NO_DEFAULT_EXCLUDES)
         "*test_*"
         "*tests*"
         "*qrc_*"
-        "ui_*.h"
-        "catch.hpp"
-        "fakeit.hpp"
+        "*ui_*.h"
+        "*catch.hpp"
+        "*fakeit.hpp"
+        "*contract.cpp"
     )
 endif()
 
@@ -77,9 +78,6 @@ if(CODE_COVERAGE)
     add_custom_command(TARGET "coverage-report"
         COMMAND ${LCOV_EXECUTABLE} --quiet --capture --directory . --base-directory ${CMAKE_SOURCE_DIR} --no-external -o ${COVERAGE_FILE} ${LCOV_REDIRECT}
         COMMAND ${LCOV_EXECUTABLE} --quiet --remove ${COVERAGE_FILE} ${CODE_COVERAGE_EXCLUDES} -o ${COVERAGE_FILE}
-        COMMAND ${LCOV_EXECUTABLE} --quiet --remove ${COVERAGE_FILE} \*test_\* -o ${COVERAGE_FILE}
-        COMMAND ${LCOV_EXECUTABLE} --quiet --remove ${COVERAGE_FILE} \*catch.hpp\* -o ${COVERAGE_FILE}
-        COMMAND ${LCOV_EXECUTABLE} --quiet --remove ${COVERAGE_FILE} \*contract.cpp\* -o ${COVERAGE_FILE}
         COMMAND ${LCOV_EXECUTABLE} --list ${COVERAGE_FILE}
         COMMAND ${LCOV_EXECUTABLE} --summary ${COVERAGE_FILE}
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}

--- a/src/CodeCoverage.cmake
+++ b/src/CodeCoverage.cmake
@@ -17,8 +17,8 @@
 # 5. Run the application(s) where you want to analyse the coverage
 #
 # 6. Generate the report by calling one of these targets:
+#    - coverage-report (string table output)
 #    - coverage-html (HTML format)
-#    - coverage-xml (cobertura XML format)
 #
 # Requirements: gcov and gcovr
 
@@ -28,13 +28,10 @@ function(ENABLE_CODE_COVERAGE)
     elseif( NOT CMAKE_BUILD_TYPE STREQUAL "Debug" )
         message(FATAL "Code coverage results with an optimized (non-Debug) build may be misleading. Code coverage will not run." )
     else()
-        set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0 -fprofile-arcs -ftest-coverage")
-        if (CMAKE_COMPILER_IS_GNUCXX AND NOT UNIX)
-            link_libraries(debug gcov)
-        endif(CMAKE_COMPILER_IS_GNUCXX AND NOT UNIX)
-        if (NOT WIN32)
+        set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0 --coverage")
+        if(NOT WIN32)
             set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fPIC")
-        endif (NOT WIN32)
+        endif(NOT WIN32)
 
         set(CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG} PARENT_SCOPE)
 


### PR DESCRIPTION
- GCC flags `-fprofile-arcs -ftest-coverage -lgcov` are obsolete and replaced with `--coverage`
- Asterisk `*` must be placed before every exclude file
- Create a zip file of the HTML report to deploy it to the GitHub releases page.

Has been successfully tested on the HAL, see PR https://github.com/barco-healthcare/hal/pull/292.
