### PR TITLE
Fix conan builds when no git repo exists

### DIFF
--- a/src/GetVersionFromGitTag.cmake
+++ b/src/GetVersionFromGitTag.cmake
@@ -35,72 +35,9 @@ if (NOT VERSION_UPDATE_FROM_GIT)
 	return()
 endif()
 
-find_package(Git)
-
-# Check if git is found...
-if (GIT_FOUND)
-	message(STATUS "Get version from git tag...")
-
-	# Get last tag from git
-	execute_process(COMMAND ${GIT_EXECUTABLE} describe --abbrev=0 --tags
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-		OUTPUT_VARIABLE ${PROJECT_NAME}_VERSION_STRING
-		OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-	#How many commits since last tag
-	execute_process(COMMAND ${GIT_EXECUTABLE} rev-list master ${${PROJECT_NAME}_VERSION_STRING}^..HEAD --count
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-		OUTPUT_VARIABLE ${PROJECT_NAME}_VERSION_AHEAD
-		OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-	# Get current commit SHA from git
-	execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-		OUTPUT_VARIABLE ${PROJECT_NAME}_VERSION_GIT_SHA
-		OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-	# Get partial versions into a list
-	string(REGEX MATCHALL "-.*$|[0-9]+" ${PROJECT_NAME}_PARTIAL_VERSION_LIST
-		${${PROJECT_NAME}_VERSION_STRING})
-
-	# Set the version numbers
-	list(GET ${PROJECT_NAME}_PARTIAL_VERSION_LIST
-		0 ${PROJECT_NAME}_VERSION_MAJOR)
-	list(GET ${PROJECT_NAME}_PARTIAL_VERSION_LIST
-		1 ${PROJECT_NAME}_VERSION_MINOR)
-	list(GET ${PROJECT_NAME}_PARTIAL_VERSION_LIST
-		2 ${PROJECT_NAME}_VERSION_PATCH)
-
-	# The tweak part is optional, so check if the list contains it
-	list(LENGTH ${PROJECT_NAME}_PARTIAL_VERSION_LIST
-		${PROJECT_NAME}_PARTIAL_VERSION_LIST_LEN)
-	if (${PROJECT_NAME}_PARTIAL_VERSION_LIST_LEN GREATER 3)
-		list(GET ${PROJECT_NAME}_PARTIAL_VERSION_LIST 3 ${PROJECT_NAME}_VERSION_TWEAK)
-		string(SUBSTRING ${${PROJECT_NAME}_VERSION_TWEAK} 1 -1 ${PROJECT_NAME}_VERSION_TWEAK)
-	endif()
-
-	# Unset the list
-	unset(${PROJECT_NAME}_PARTIAL_VERSION_LIST)
-
-	# Set full project version string
-	set(${PROJECT_NAME}_VERSION_STRING_FULL
-		${${PROJECT_NAME}_VERSION_STRING}+${${PROJECT_NAME}_VERSION_AHEAD}.${${PROJECT_NAME}_VERSION_GIT_SHA})
-
-	# Save version to file (which will be used when Git is not available
-	# or VERSION_UPDATE_FROM_GIT is disabled)
-	file(WRITE ${CMAKE_SOURCE_DIR}/VERSION ${${PROJECT_NAME}_VERSION_STRING_FULL}
-		"|" ${${PROJECT_NAME}_VERSION_STRING}
-		"|" ${${PROJECT_NAME}_VERSION_MAJOR}
-		"|" ${${PROJECT_NAME}_VERSION_MINOR}
-		"|" ${${PROJECT_NAME}_VERSION_PATCH}
-		"|" ${${PROJECT_NAME}_VERSION_TWEAK}
-		"|" ${${PROJECT_NAME}_VERSION_AHEAD}
-		"|" ${${PROJECT_NAME}_VERSION_GIT_SHA})
-
-	message("Version file (over)written: ${CMAKE_SOURCE_DIR}/VERSION")
-
-else()
-
+# First check for VERSION File, and use that first
+if (EXISTS "${CMAKE_SOURCE_DIR}/VERSION")
+    message(STATUS "Reading version from File")
 	# Git not available, get version from file
 	file(STRINGS ${CMAKE_SOURCE_DIR}/VERSION ${PROJECT_NAME}_VERSION_LIST)
 	string(REPLACE "|" ";" ${PROJECT_NAME}_VERSION_LIST ${${PROJECT_NAME}_VERSION_LIST})
@@ -113,9 +50,71 @@ else()
 	list(GET ${PROJECT_NAME}_VERSION_LIST 5 ${PROJECT_NAME}_VERSION_TWEAK)
 	list(GET ${PROJECT_NAME}_VERSION_LIST 6 ${PROJECT_NAME}_VERSION_AHEAD)
 	list(GET ${PROJECT_NAME}_VERSION_LIST 7 ${PROJECT_NAME}_VERSION_GIT_SHA)
+else()
+    find_package(Git)
+    # Check if git is found...
+    if (GIT_FOUND)
+        message(STATUS "Get version from git tag...")
 
+        # Get last tag from git
+        execute_process(COMMAND ${GIT_EXECUTABLE} describe --abbrev=0 --tags
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            OUTPUT_VARIABLE ${PROJECT_NAME}_VERSION_STRING
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+        #How many commits since last tag
+        execute_process(COMMAND ${GIT_EXECUTABLE} rev-list master ${${PROJECT_NAME}_VERSION_STRING}^..HEAD --count
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            OUTPUT_VARIABLE ${PROJECT_NAME}_VERSION_AHEAD
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+        # Get current commit SHA from git
+        execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            OUTPUT_VARIABLE ${PROJECT_NAME}_VERSION_GIT_SHA
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+        # Get partial versions into a list
+        string(REGEX MATCHALL "-.*$|[0-9]+" ${PROJECT_NAME}_PARTIAL_VERSION_LIST
+            ${${PROJECT_NAME}_VERSION_STRING})
+
+        # Set the version numbers
+        list(GET ${PROJECT_NAME}_PARTIAL_VERSION_LIST
+            0 ${PROJECT_NAME}_VERSION_MAJOR)
+        list(GET ${PROJECT_NAME}_PARTIAL_VERSION_LIST
+            1 ${PROJECT_NAME}_VERSION_MINOR)
+        list(GET ${PROJECT_NAME}_PARTIAL_VERSION_LIST
+            2 ${PROJECT_NAME}_VERSION_PATCH)
+
+        # The tweak part is optional, so check if the list contains it
+        list(LENGTH ${PROJECT_NAME}_PARTIAL_VERSION_LIST
+            ${PROJECT_NAME}_PARTIAL_VERSION_LIST_LEN)
+        if (${PROJECT_NAME}_PARTIAL_VERSION_LIST_LEN GREATER 3)
+            list(GET ${PROJECT_NAME}_PARTIAL_VERSION_LIST 3 ${PROJECT_NAME}_VERSION_TWEAK)
+            string(SUBSTRING ${${PROJECT_NAME}_VERSION_TWEAK} 1 -1 ${PROJECT_NAME}_VERSION_TWEAK)
+        endif()
+
+        # Unset the list
+        unset(${PROJECT_NAME}_PARTIAL_VERSION_LIST)
+
+        # Set full project version string
+        set(${PROJECT_NAME}_VERSION_STRING_FULL
+            ${${PROJECT_NAME}_VERSION_STRING}+${${PROJECT_NAME}_VERSION_AHEAD}.${${PROJECT_NAME}_VERSION_GIT_SHA})
+
+        # Save version to file (which will be used when Git is not available
+        # or VERSION_UPDATE_FROM_GIT is disabled)
+        file(WRITE ${CMAKE_SOURCE_DIR}/VERSION ${${PROJECT_NAME}_VERSION_STRING_FULL}
+            "|" ${${PROJECT_NAME}_VERSION_STRING}
+            "|" ${${PROJECT_NAME}_VERSION_MAJOR}
+            "|" ${${PROJECT_NAME}_VERSION_MINOR}
+            "|" ${${PROJECT_NAME}_VERSION_PATCH}
+            "|" ${${PROJECT_NAME}_VERSION_TWEAK}
+            "|" ${${PROJECT_NAME}_VERSION_AHEAD}
+            "|" ${${PROJECT_NAME}_VERSION_GIT_SHA})
+
+        message("Version file (over)written: ${CMAKE_SOURCE_DIR}/VERSION")
+    endif()
 endif()
-
 
 # Set project version (without the preceding 'v')
 set(${PROJECT_NAME}_VERSION ${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_VERSION_MINOR}.${${PROJECT_NAME}_VERSION_PATCH})


### PR DESCRIPTION
Conan doesn't grab the repo information, when building. This will cause a problem on our CI builds, when Git is installed, but no repo information.

So, now it will check for if VERSION file exist, and then use it. If it doesn't see the file, it will create it assuming the git information is there. 