### PR TITLE
Check that git repo also exists, needed for conan create

### DIFF
--- a/src/GetVersionFromGitTag.cmake
+++ b/src/GetVersionFromGitTag.cmake
@@ -38,7 +38,7 @@ endif()
 find_package(Git)
 
 # Check if git is found...
-if (GIT_FOUND)
+if (GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
 	message(STATUS "Get version from git tag...")
 
 	# Get last tag from git


### PR DESCRIPTION
When git tag versioning was enabled, the conan didn't create a package successfully because the conan source directory was not a git repo.

See attempt to fix it by Tom here https://github.com/barco-healthcare/hal/pull/297.
I rejected this because I want to give priority to getting the tag from git iso the VERSION.
When building twice, the version would be still the old version.