### PR TITLE
Clang compiler linker error fix for Ubuntu (22.04)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
 

--- a/src/CompilerFlags.cmake
+++ b/src/CompilerFlags.cmake
@@ -8,7 +8,6 @@ IF(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
    SET(CMAKE_BUILD_TYPE RelWithDebInfo)
 ENDIF(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 
-
 if(CMAKE_COMPILER_IS_GNUCXX)
     set(COMPILER_FLAGS
                     "-std=c++11"
@@ -86,7 +85,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
 
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(COMPILER_FLAGS
-                        "-stdlib=libc++"
+#                        "-stdlib=libc++"                   # Doesn't work with Clang11 on Ubuntu (22.04), causes Linker errors
                         "-std=c++11"
                         "-Wall"                             # turn on all warnings
                         "-Wpedantic"

--- a/src/CompilerFlags.cmake
+++ b/src/CompilerFlags.cmake
@@ -85,7 +85,6 @@ if(CMAKE_COMPILER_IS_GNUCXX)
 
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(COMPILER_FLAGS
-#                        "-stdlib=libc++"                   # Doesn't work with Clang11 on Ubuntu (22.04), causes Linker errors
                         "-std=c++11"
                         "-Wall"                             # turn on all warnings
                         "-Wpedantic"


### PR DESCRIPTION
- Please delete the v3.0.1 tag & release and replace it with the master branch after this PR